### PR TITLE
Ajout indication sur la familiarisation pour contribuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ N'hésite pas à partager d'éventuels projets en lien avec les modèles ouverts
 
 La brique repose sur le collaboration ouverte, tu es libre de participer. Toute contribution externe sera la bienvenue et permettra d'enrichir le projet.
 
+La familiarisation avec les modèles ouverts et les différents espaces de la brique vont aider à être à l'aise pour contribuer, prends le temps d'explorer l'environnement, les différents outils, les différents échanges en cours.
+
 Le [guide de contribution](guide-contribution.md) permet de découvrir les (quelques) possibilités d'aider.
 
 ## Licences ⚖️


### PR DESCRIPTION
Pour contribuer à un projet ouvert, une phase de familiarisation à lieux. Ajout de cette information pour expliciter ce fait, pour chercher à faire comprendre qu'il y a un temps d'apprentissage.