### PR TITLE
open hardware: ajout thingiverse dans la liste des projets

### DIFF
--- a/contenu/modèles/open-hardware.md
+++ b/contenu/modèles/open-hardware.md
@@ -11,3 +11,4 @@ Source : [Open Source Hardware Association](https://www.oshwa.org/definition/fre
 - [Open Source Ecology](https://www.opensourceecology.org/)
 - [PinePhone](https://www.pine64.org/)
 - [Liste de projets open hardware](https://en.wikipedia.org/wiki/List_of_open-source_hardware_projects)
+- [Thingiverse](https://www.thingiverse.com/)


### PR DESCRIPTION
Ajout du projet thingiverse, base de données pour objets à imprimante 3D