### PR TITLE
liste modèles: fix des liens

### DIFF
--- a/contenu/modèles/README.md
+++ b/contenu/modèles/README.md
@@ -2,11 +2,11 @@
 
 **[Page en construction, voir [#2](https://github.com/Open-Models/Brique/issues/2)]**
 
-- [Open Science](/contenu/modèles/open-science.md)
-- [Open Collaboration](/contenu/modèles/open-collaboration.md)
-- [Open Hardware](/contenu/modèles/open-hardware.md)
-- [Open Innovation](/contenu/modèles/open-innovation.md)
-- [Open Peer Review](/contenu/modèles/open-peer-review.md)
+- [Open Science](open-science.md)
+- [Open Collaboration](open-collaboration.md)
+- [Open Hardware](open-hardware.md)
+- [Open Innovation](open-innovation.md)
+- [Open Peer Review](open-peer-review.md)
 - Open Source
 - Open Open Standards
 - Open Access


### PR DESCRIPTION
Les liens des différents modèles ne fonctionnaient pas correctement sur le site et entrainait le téléchargement d'un fichier markdown.