### PR TITLE
Open Science page: ajout European Open Science Cloud

### DIFF
--- a/contenu/modèles/open-science.md
+++ b/contenu/modèles/open-science.md
@@ -26,6 +26,7 @@ Des réseaux d'universités se mettent en place et choisissent de partager leurs
 - [Open Edition](https://www.openedition.org/)
 - [Science Open](https://www.scienceopen.com/)
 - [Zenodo](https://zenodo.org/)
+- [European Open Science Cloud](https://eosc-portal.eu/)
 
 ### Acteurs
 


### PR DESCRIPTION
"L'initiative European Open Science Cloud de la Commission européenne vise à développer un dispositif fournissant à ses utilisateurs des services d'informatique en nuage pour les pratiques de science ouverte" - Wikipedia