### PR TITLE
Ajout média Les communs d'abord

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -1,5 +1,11 @@
 # Liste de ressources sur les modèles ouverts
 
+## Médias
+
+- [Les communs d'abord](https://www.les-communs-dabord.org/)
+- [Blog open source de Google](https://opensource.googleblog.com/)
+- [Open Science Magazine](https://open-science-future.zbw.eu/en/)
+
 ## Livres
 
 - [The Cathedral and the Bazaar](http://www.catb.org/~esr/writings/cathedral-bazaar/cathedral-bazaar/index.html#catbmain) - Eric S. Raymond


### PR DESCRIPTION
Ajout d'une nouvelle section pour les médias en liens avec les modèles ouverts et les communs numériques.

Forcément d'autres je pense, mais je n'ai aucun qui me vient en tête.