### PR TITLE
open science : ajout acteur SPARC

### DIFF
--- a/contenu/modèles/open-science.md
+++ b/contenu/modèles/open-science.md
@@ -32,6 +32,7 @@ Des réseaux d'universités se mettent en place et choisissent de partager leurs
 
 - [Ouvrir la science](https://www.ouvrirlascience.fr/)
 - [Center For Open Science](https://www.cos.io/)
+- [SPARC](https://sparcopen.org/)
 
 ### Politiques
 


### PR DESCRIPTION
"SPARC is a non-profit advocacy organization that supports systems for research and education that are open by default and equitable by design. We believe everyone should be able to access and contribute to the knowledge that shapes our world. "