### PR TITLE
liste modèles : Ajout d'une liste entière des modèles connus

### DIFF
--- a/contenu/modèles/README.md
+++ b/contenu/modèles/README.md
@@ -7,10 +7,18 @@
 - [Open Hardware](open-hardware.md)
 - [Open Innovation](open-innovation.md)
 - [Open Peer Review](open-peer-review.md)
-- Open Source
-- Open Open Standards
 - Open Access
+- Open Business
+- Open Banking
 - Open Cloud
+- Open Content
 - Open Data
+- Open Government
 - Open Health
-- ...
+- Open Journalism
+- Open Knowledge
+- Open Law
+- Open Music
+- Open Patent
+- Open (Source) Software
+- Open Standard


### PR DESCRIPTION
En lien avec https://github.com/Open-Models/Brique/issues/2.

Ajout dans la liste des [modèles ouverts](https://open-models.org/contenu/mod%C3%A8les/) l'ensemble des modèles connus, sans aucune description. Recensement fait notamment dans l'optique de création d'une nouvelle image de couteau suisse pour l'intro sur les modèles ouverts : https://github.com/Open-Models/Brique/issues/50.

J'essaye de prendre des termes assez utilisés quand même, avec une reprise dans wikipédia idéalement, où qui semble avoir une certaine notoriété comme Open Cloud. Open Patent et Open Health sont un peu limite (pas de page wikipédia), Open Health étant en partie repris de l'ancien couteau suisse, l'open patent parce que c'est un peu utilisé et pour montrer clairement que ça touche les brevets et qu'il y a quelques initatives autour. L'open innovation permet de parler brevet en général, mais c'est d'autant plus explicite ainsi.

Je n'ai pas tout listé, par exemple je connais une initiative sur l'[urbanisme ouvert](https://urbanismeouvert.ch/fr), mais je crois que c'est encore porté par une structure seule, je ne suis pas sûr du fait de le citer ou non. En même temps ça permet de promouvoir la dynamique, en même temps c'est très peu défini. Faut-il lister un modèle tôt ou attendre que ce soit suffisament mature ?

D'autres modèles ouverts à lister ?