### PR TITLE
open science : ajout plateforme ResearchGate

### DIFF
--- a/contenu/modèles/open-science.md
+++ b/contenu/modèles/open-science.md
@@ -28,6 +28,7 @@ Des réseaux d'universités se mettent en place et choisissent de partager leurs
 - [Zenodo](https://zenodo.org/)
 - [European Open Science Cloud](https://eosc-portal.eu/)
 - [In&Sight](https://inandsight.science/)
+- [ResearchGate](https://www.researchgate.net/)
 
 ### Acteurs
 


### PR DESCRIPTION
"ResearchGate est un [site](https://fr.wikipedia.org/wiki/Site_Web) proposant un service de [réseautage social](https://fr.wikipedia.org/wiki/R%C3%A9seautage_social) pour chercheurs et scientifiques de toutes disciplines. Disponible gratuitement, il permet une recherche scientifique sémantique[2](https://fr.wikipedia.org/wiki/ResearchGate#cite_note-2) ainsi qu'une chronique de fichiers partagés. Le site propose aussi un [serveur de fichiers](https://fr.wikipedia.org/wiki/Serveur_de_fichiers) publics (comme une gestion de littératures par notes en base de page), un forum, des discussions méthodologiques et des groupes d'échanges." - Wikipédia