### PR TITLE
open science : ajout plateforme springeropen

### DIFF
--- a/contenu/modèles/open-science.md
+++ b/contenu/modèles/open-science.md
@@ -29,6 +29,7 @@ Des réseaux d'universités se mettent en place et choisissent de partager leurs
 - [European Open Science Cloud](https://eosc-portal.eu/)
 - [In&Sight](https://inandsight.science/)
 - [ResearchGate](https://www.researchgate.net/)
+- [SpringerOpen](https://www.springeropen.com/)
 
 ### Acteurs
 


### PR DESCRIPTION
Le portefeuille SpringerOpen s'est considérablement étoffé depuis son
lancement en 2010, de sorte que nous offrons désormais aux chercheurs de
tous les domaines des sciences, de la technologie, de la médecine, des
sciences humaines et sociales un lieu de publication en libre accès dans
des revues.