### PR TITLE
Méthode : changement projet ouvert par commun

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Toutes les informations relatives aux modèles ouverts sont listées ici.
 **[EN CONSTRUCTION, voir [l'ébauche de plan](https://github.com/Open-Models/Brique/issues/1)]**
 - [Introduction aux modèles ouverts](contenu/introduction.md)
 - [Histoire des modèles ouverts](contenu/histoire.md)
-- [Méthode de construction d'un projet ouvert](contenu/methode/README.md)
+- [Méthode de construction d'un commun numérique](contenu/methode/README.md)
 - [Liste des modèles ouverts](contenu/modèles/README.md)
 - [Liste de projets](contenu/projets/README.md)
 

--- a/contenu/methode/README.md
+++ b/contenu/methode/README.md
@@ -1,12 +1,15 @@
-## Méthode gestion de projet ouvert
+## Méthode de construction d'un commun numérique
 
 **[EN CONSTRUCTION, voir [#4](https://github.com/Open-Models/Brique/issues/4)]**
 
-Malgré le contenu ici, la construction de la méthode n'a pas commencé et n'est pas structurée.
+Malgré le contenu ici, la construction de la méthode n'a pas commencée et n'est pas structurée.
 
 Temporairement, reprise d'un ensemble de post linkedIn tel quel pour esquisser quelques principes et permettre une certaine assimilation du sujet.
 
-Pour comprendre certaines dynamiques qui permettent la collaboration ouverte sur de des ressources open source.
+Les modèles ouverts s'appuient bien souvent (mais pas uniquement) sur la mise en place de commun numérique,
+une ressource informationnelle co-produite par une communauté qui bénéficie d'une liberté d'usage et dont la gouvernance est partagée.
+
+Tout un ensemble de stratégies permet de structurer un commun numérique, nous cherchons aujourd'hui une certaine méthodologie.
 
 - **Règle n°1** : [Faire un projet qui a du sens et se base sur une utilité commune](regle-1.md)
 - **Règle n°2** : [Travailler et communiquer publiquement](regle-2.md)


### PR DESCRIPTION
Renommage de la notion de projet ouvert en commun numérique. On pourrait voir des subtilités entre les 2, mais le terme de commun est davantage utilisé, ce qui permet de mieux s'appuyer sur cette notion.