### PR TITLE
introduction : mise à jour définition 'modèles ouverts'

### DIFF
--- a/contenu/introduction.md
+++ b/contenu/introduction.md
@@ -1,6 +1,6 @@
 ## Les Modèles Ouverts
 
-> **Modèles ouverts** : Modes d'organisation et de production du savoir basés sur l'open source et la collaboration ouverte.
+> **Modèles ouverts** : Modes d'organisation et de production des connaissances s'appuyant sur le numérique, la libre circulation de l'information et la collaboration à l'échelle d'Internet qui cherchent à bénéficier des propriétés provenant de l'interaction entre écosystèmes.
 
 <p align="center" width="100%">
     <img src="https://raw.githubusercontent.com/Open-Models/Brique/main/images/modele_ouverts.png">


### PR DESCRIPTION
Suite de https://github.com/Open-Models/Brique/issues/49

Proposition de modification de la définition, l'ancienne étant plus imparfaite que celle-ci.

Retrait de l'usage de terme en lien avec les modèles ouverts (open collaboration/open source).  Toujours bien difficile d'avoir une définition complète, l'idée étant de faire un pas vers une explication plus correcte.

**Proposition actuelle :** 
> Modes d'organisation et de production des connaissances s'appuyant sur le numérique, la libre circulation de l'information et la collaboration à l'échelle d'Internet qui cherchent à bénéficier des propriétés provenant de l'interaction entre écosystèmes.