### PR TITLE
titre : uniformisation header sur le site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,8 +16,8 @@
     <a id="skip-to-content" href="#content">Skip to the content.</a>
 
     <header class="page-header" role="banner">
-      <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
-      <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
+      <h1 class="project-name">Modèles ouverts</h1>
+      <h2 class="project-tagline">Brique de connaissances</h2>
       {% if site.github.is_project_page %}
           <a href="{{ site.url }}{{ site.baseurl }}" class="btn">Accueil Brique</a>
       {% endif %}


### PR DESCRIPTION
Changement des headers de toutes les pages par : "Modèles ouverts \</br> Brique de connaissances"
![Screenshot from 2022-09-23 01-16-36](https://user-images.githubusercontent.com/34010605/191867988-758ac84f-8f63-479a-b8ca-ec3d72a13910.png)

Utilise actuellement la description du dépôt Github sur la page d'accueil, ou répète le premier titre sur les autres pages.

**Ancienne version (sur le site actuellement)** : 
![Screenshot from 2022-09-23 01-23-06](https://user-images.githubusercontent.com/34010605/191868240-aeb74c35-5123-4c9d-b191-1ca89e8a7251.png)
