### PR TITLE
Listing modèle open license

### DIFF
--- a/contenu/modèles/README.md
+++ b/contenu/modèles/README.md
@@ -24,3 +24,4 @@
 - Open Standard
 - Open Pedagogy
 - Open Design
+- Open License


### PR DESCRIPTION
Le terme open licence semble utiliser pour rassembler ces différentes familles de licences qui permettent les modèles ouverts.

Il semble que ce soit une évolution sémantique qui suit l'idée des licences libres : https://en.wikipedia.org/wiki/Free_license