### PR TITLE
Open Hardware : Ajout Open Compute Project

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -131,6 +131,7 @@
 - 🕴️ [Arduino](https://www.arduino.cc/)
 - [Open Source Ecology](https://www.opensourceecology.org/)
 - 🕴️ [PinePhone](https://www.pine64.org/)
+- 🕴️ [Open Compute Project](https://www.opencompute.org/)
 - 📰 [Liste de projets open hardware](https://en.wikipedia.org/wiki/List_of_open-source_hardware_projects)
 - 📚 [Thingiverse](https://www.thingiverse.com/)
 


### PR DESCRIPTION
The Open Compute Project Foundation (OCP) was initiated in 2011 with a mission to apply the benefits of open source and open collaboration to hardware and rapidly increase the pace of innovation in, near and around the data center.