### PR TITLE
open hardware : ajout atelier paysan

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -130,6 +130,7 @@
 - 🎥 [Le libre et l'open source des logiciels et objets - monsieur Bidouille](https://www.youtube.com/watch?v=y2GNVGagWdM)
 - 🕴️ [Arduino](https://www.arduino.cc/)
 - [Open Source Ecology](https://www.opensourceecology.org/)
+- 🕴️ [L'Atelier Paysan](https://www.latelierpaysan.org/)
 - 🕴️ [PinePhone](https://www.pine64.org/)
 - 📰 [Liste de projets open hardware](https://en.wikipedia.org/wiki/List_of_open-source_hardware_projects)
 - 📚 [Thingiverse](https://www.thingiverse.com/)


### PR DESCRIPTION
Recense et en diffuse librement les outils, les machines et les bâtiments, créés par ces paysans et paysannes.

Accompagnement à la mise en place de projet et éducation autour de ces logiques de partages.