### PR TITLE
awesome : ajout article risque commercialisation open science

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -130,6 +130,7 @@
 - 👩🏽‍🔬 [Point of View: How open science helps researchers succeed](https://elifesciences.org/articles/16800)
 - 👩🏽‍🔬 [L’archive ouverte HAL-SHS : Comment ça marche, pourquoi s’en servir ?](https://archivesic.ccsd.cnrs.fr/sic_00407275/file/Emigrinter2009_HALSHS.pdf), [2009]
 - 👩🏽‍🔬 [Amplifying the impact of open access: Wikipedia and the diffusion of science](https://asistdl.onlinelibrary.wiley.com/doi/full/10.1002/asi.23687)
+- 👩🏽‍🔬 [Open Science for private Interests? How the Logic of Open Science Contributes to the Commercialization of Research](https://www.frontiersin.org/articles/10.3389/frma.2020.588331/full)
 - 🛠️ [Core](https://core.ac.uk/)
 - 🛠️ [Sci-Hub](https://fr.wikipedia.org/wiki/Sci-Hub)
 - 🛠️ [Libgen](https://fr.wikipedia.org/wiki/Library_Genesis), moteur de recherche d'articles et de livres


### PR DESCRIPTION
Article qui critique la démarche actuelle de l'open science qui cible principalement la recherche financée sur fond public, l'intérêt du privé à promouvoir ces logiques pour l'accaparer, et la création de toute une industrie de la connaissance s'appuyant sur l'open science.