### PR TITLE
awesome : ajout open science article flawed reality

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -134,6 +134,7 @@
 - 👩🏽‍🔬 [L’archive ouverte HAL-SHS : Comment ça marche, pourquoi s’en servir ?](https://archivesic.ccsd.cnrs.fr/sic_00407275/file/Emigrinter2009_HALSHS.pdf), [2009]
 - 👩🏽‍🔬 [Amplifying the impact of open access: Wikipedia and the diffusion of science](https://asistdl.onlinelibrary.wiley.com/doi/full/10.1002/asi.23687)
 - 👩🏽‍🔬 [Open Science for private Interests? How the Logic of Open Science Contributes to the Commercialization of Research](https://www.frontiersin.org/articles/10.3389/frma.2020.588331/full)
+- 👩🏽‍🔬 [Open access publishing – noble intention, flawed reality](https://www.sciencedirect.com/science/article/pii/S027795362200898X)
 - 🛠️ [Core](https://core.ac.uk/)
 - 🛠️ [Sci-Hub](https://fr.wikipedia.org/wiki/Sci-Hub)
 - 🛠️ [Libgen](https://fr.wikipedia.org/wiki/Library_Genesis), moteur de recherche d'articles et de livres


### PR DESCRIPTION
Partage d'un certain nombre de problématique dont l'ingégalité à l'accès des publications à cause des APC, les journaux prédateurs qui atteindraient plus facilement les plus précaires (double peine).

“Unfortunately, the APC approach hurts peripheral scholars who otherwise have greatly benefited from the growth of OA publishing. These financial (and other) barriers to publishing create a demand for ‘sub-standard journals.’ Publishing in those, to a large extent, diminishes the reputation of work carried out. This reinforces the existing dichotomy between scholars in wealthier and those in relatively poorer research situations and diminishes the idea of knowledge as a common good, equally shared, and created, by all.”