### PR TITLE
awesome : open science ajout numfocus

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -174,6 +174,7 @@
 - 🕴️ [Center For Open Science](https://www.cos.io/)
 - 🕴️ [SPARC](https://sparcopen.org/)
 - 🕴️ [Electronic Information for Libraries (EIFL)](https://www.eifl.net/)
+- 🕴️ [NumFOCUS](https://numfocus.org), support pour logiciels scientifique open source
 - 🕴️ [Facilitate Open Science Training for European Research (FOSTER)](https://www.fosteropenscience.eu/)
 - 🕴️ 🇪🇺 [Plan S](https://www.coalition-s.org/), coalition (cOAlition S) de financeurs public/privé de la recherche
 - 🕴️ [Portail Open Science Centre Européen pour la Recherche Nucléaire (CERN)](https://openscience.cern/)


### PR DESCRIPTION
The mission of NumFOCUS is to promote open practices in research, data, and scientific computing by serving as a fiscal sponsor for open source projects and organizing community-driven educational programs.

Travis Oliphant (author of NumPy), Fernando Pérez (author of IPython), Perry Greenfield (author of Numarray and Astropy), John Hunter (author of Matplotlib), Jarrod Millman (release manager for SciPy), and Anthony Scopatz (who came up with the name “NumFOCUS”) became the founding board of NumFOCUS. Leah Silen was selected as the founding Executive Director. In fall of 2012, NumFOCUS received 501(c)(3) public charity status as a nonprofit in the United States.