### PR TITLE
awesome : ajout coalitions organisations open source nationale

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -100,6 +100,10 @@
 - 🕴️ 🇬🇧 [OpenUk](https://openuk.uk/)
 - 🕴️ 🇫🇷 [Conseil National du Logiciel Libre](https://cnll.fr/)
 - 🕴️ 🇫🇷 [Clusters d'entreprises du logiciel open source](https://cnll.fr/cnll/membres/), adhérents du CNLL
+- 🕴️ 🇩🇪 [Open Source Business (OSB) Alliance](https://osb-alliance.de/)
+- 🕴️ 🇮🇹 [Rete Italiana Open Source](https://www.reteitalianaopensource.net/) (RIOS)
+- 🕴️ 🇪🇸 [Federación ASOLIF](https://twitter.com/asolif_empresas)
+- 🕴️ 🇵🇹 [Associação de Empresas de Software Open Source Portuguesas](https://www.esop.pt/) (ESOP)
 - 🕴️ 🇪🇺 [OW2](https://www.ow2.org/), European Open Source Software Community
 - 🕴️ [Open Source Security Foundation](https://openssf.org/)
 - 🕴️ [Free/Libre and Open Source Software (FLOSS) foundations](https://flossfoundations.org/foundation-directory/)


### PR DESCRIPTION
Ajout de plusieurs association qui rassemblent des organisations du monde de l'open source.

Des organisation qui permettent la promotion de l'open source et de structurer l'écosystème, de faire échanger les acteurs (évènements), de former, etc.

Équivalents du CNLL en France, ajout pour l'Italie, Espagne, Portugal et Allemagne.