### PR TITLE
awesome : open science ajout society for scholarly publishing

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -125,6 +125,7 @@
 
 ## Open Science
 
+- 📡 [The Scholarly Kitchen](https://scholarlykitchen.sspnet.org/), blog de la SSP sur l'édition savante
 - 📡 [Open Science Magazine](https://open-science-future.zbw.eu/en/)
 - 📖 [Opening Science](http://www.openingscience.org/get-the-book/), Sönke Bartling & Sascha Friesike
 - 👩‍🎓 🇫🇷 [MOOC La science ouverte](https://www.fun-mooc.fr/fr/cours/la-science-ouverte/), par France Université Numérique (FUN) MOOC
@@ -185,6 +186,7 @@
 - 🕴️ [Center For Open Science](https://www.cos.io/)
 - 🕴️ [SPARC](https://sparcopen.org/)
 - 🕴️ [Electronic Information for Libraries (EIFL)](https://www.eifl.net/)
+- 🕴️ [Society for Scholarly Publishing](https://www.sspnet.org/) (SSP)
 - 🕴️ [NumFOCUS](https://numfocus.org), support pour logiciels scientifique open source
 - 🕴️ [Facilitate Open Science Training for European Research (FOSTER)](https://www.fosteropenscience.eu/)
 - 🕴️ [Radical Open Access](https://radicaloa.disruptivemedia.org.uk/)


### PR DESCRIPTION
Acteur dans la communication scientifique + ajout blog "The Scholarly Kitchen" de la SSP

The Society for Scholarly Publishing (SSP), founded in 1978, is a nonprofit organization formed to promote and advance communication among all sectors of the scholarly publication community through networking, information dissemination, and facilitation of new developments in the field.