### PR TITLE
awesome : ajout Open Access Publishing in European Networks (OAPEN)

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -151,6 +151,7 @@
 - 📚 [HAL archive ouverte](https://hal.archives-ouvertes.fr/)
 - 📚 [Theses.fr](https://www.theses.fr/fr/)
 - 📚 [Open Edition](https://www.openedition.org/)
+- 📚 [Open Access Publishing in European Networks](https://www.oapen.org/) (OAPEN)
 - 📚 [Science Open](https://www.scienceopen.com/)
 - 📚 [Zenodo](https://zenodo.org/)
 - 📚 [In&Sight](https://inandsight.science/)


### PR DESCRIPTION
About us

The OAPEN Foundation is a not-for-profit organisation based in the Netherlands, with its registered office at the National Library in The Hague. OAPEN is dedicated to open access, peer-reviewed books.

OAPEN operates three platforms:

- OAPEN Library - a central repository for hosting and disseminating OA books
- OAPEN Open Access Books Toolkit - a toolkit on OA book publishing for authors
- Directory of Open Access Books - a discovery service indexing OA books, in partnership with OpenEdition