### PR TITLE
awesome: open standard ajout schema.org

### DIFF
--- a/awesome-list.md
+++ b/awesome-list.md
@@ -300,6 +300,7 @@
 ## Open Standard
 
 - 🏦 🇪🇺[Interoperable Europe Act](https://ec.europa.eu/commission/presscorner/detail/fr/ip_22_6907)
+- 📚 [Schema.org](https://schema.org/), create, maintain, and promote schemas for structured data on the Internet, on web pages, in email messages, and beyond
 - 🛠️ [RISC-V](https://riscv.org/), Instruction Set Architecture (computer architecture)
 - 🛠️ [OAI-PMH](http://www.openarchives.org/OAI/openarchivesprotocol.html), protocole de récolte de métadonnées
 - 🛠️ [Dublin Core](https://dublincore.org/), schéma de métadonnées pour ressources numériques


### PR DESCRIPTION
Schema.org vocabulary can be used with many different encodings, including RDFa, Microdata and JSON-LD. These vocabularies cover entities, relationships between entities and actions, and can easily be extended through a well-documented extension model.

Founded by Google, Microsoft, Yahoo and Yandex, Schema.org vocabularies are developed by an open community process, using the public-schemaorg__AT__w3.org mailing list and through GitHub.