### PR TITLE
ressources : ajout Center for Open Education Research (COER)

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -242,6 +242,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🕴️ [Open EdTech](https://www.openedtech.global/), designing a global NextGen educational open source platform
 - 🕴️ 🇫🇷 [Fabrique des Communs Pédagogiques](https://fabpeda.org/)
 - 🕴️ [Open Schools for Open Societies](https://www.openschools.eu/)
+- 🕴️ [Center for Open Education Research](https://uol.de/coer) (COER), Oldenburg university (🇩🇪)
 - 👩🏽‍🔬 🇫🇷 [Sondage annuel (depuis 2014) usage numérique chez les enseignants](https://www.ac-paris.fr/sondage-sur-les-usages-du-numerique-123944)
 - 📰 [Alternatives to paying for pricey textbooks](https://sanjosespotlight.com/rodriguez-alternatives-to-paying-for-pricey-textbooks/)
 - 📖 [Handook of Open, Distance and Digital Education](https://link.springer.com/referencework/10.1007/978-981-19-2080-6)


### PR DESCRIPTION
The Center for Open Education Research (COER) is an international research consortium, that was established in 2018 in order to increase international collaborative research projects, furthering innovation and understanding in the areas of open education, educational technology, lifelong learning and international education.