### PR TITLE
ressources : ajout journal Education Ouverte et Libre - Open Education

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -243,6 +243,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🕴️ 🇫🇷 [Fabrique des Communs Pédagogiques](https://fabpeda.org/)
 - 🕴️ [Open Schools for Open Societies](https://www.openschools.eu/)
 - 👩🏽‍🔬 🇫🇷 [Sondage annuel (depuis 2014) usage numérique chez les enseignants](https://www.ac-paris.fr/sondage-sur-les-usages-du-numerique-123944)
+- 📡 👩🏽‍🔬 Journal [Education Ouverte et Libre - Open Education](https://oap.unige.ch/journals/eol-oe)
 - 📰 [Alternatives to paying for pricey textbooks](https://sanjosespotlight.com/rodriguez-alternatives-to-paying-for-pricey-textbooks/)
 - 📖 [Handook of Open, Distance and Digital Education](https://link.springer.com/referencework/10.1007/978-981-19-2080-6)
 


### PR DESCRIPTION
Education Ouverte et Libre - Open Education is a multilingual scientific journal that aims to reflect, discuss and think about Open Education issues at the international level. Following the UNESCO (2021) recommendations on open science and particularly the "open dialogue with other knowledge systems", the journal offers a space to reflect on all aspects of the educational ecosystem in an open and free paradigm.