### PR TITLE
ressources : ajout OSS.Fund

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -144,6 +144,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🛠️ [FundOSS](https://fundoss.org/)
 - 🛠️ [Free Software Fund](https://www.fsf.org/working-together/fund) (FSF)
 - 🛠️ [Copie Publique](https://copiepublique.fr/), crowfunding d'entreprises pour support brique logicielle
+- 🛠️ [OSS.Fund](https://www.oss.fund/), catalog of monetization platforms for open source builders
 - 🛠️ [NGI Search](https://www.ngisearch.eu/), Funding the Next Generation of (open source) Web Searching Tools
 - 🛠️ [Open Collective](https://opencollective.com/), legal and financial toolbox for grassroots groups
 - 🛠️ [Open Source JobHub](https://opensourcejobhub.com/)


### PR DESCRIPTION
OSS.Fund is a catalog of monetization platforms for open source builders. It helps independent creators find the best monetization platform for their needs and financially survive while growing a community. It is curated and maintained as a crowdsourced list on Github.