### PR TITLE
ressources : ajout stratégie du numérique pour l'éducation France

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -245,6 +245,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 👩🏽‍🔬 🇫🇷 [Sondage annuel (depuis 2014) usage numérique chez les enseignants](https://www.ac-paris.fr/sondage-sur-les-usages-du-numerique-123944)
 - 📰 [Alternatives to paying for pricey textbooks](https://sanjosespotlight.com/rodriguez-alternatives-to-paying-for-pricey-textbooks/)
 - 📖 [Handook of Open, Distance and Digital Education](https://link.springer.com/referencework/10.1007/978-981-19-2080-6)
+- 🏦 🇫🇷 [Stratégie du numérique pour l'Éducation Nationale](https://www.education.gouv.fr/strategie-du-numerique-pour-l-education-2023-2027-344263) (2023-2027)
 
 ## Open Innovation
 


### PR DESCRIPTION
Stratégie publiée par le Ministère de l'Éducation Nationale, incluant de nombreux aspects en faveur de l'utilisation et du soutien aux communs numériques, autant logiciels que ressources pédagogiques, données...