### PR TITLE
ressources : Deconstructing Software copyright, 30 years of bad logic

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -89,6 +89,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 📰 [Awesome maintainers](https://github.com/nayafia/awesome-maintainers) - *"Talks, blog posts, and interviews about the experience of being an open source maintainer"*
 - 📰 [Time Till Open Source Alternative](https://staltz.com/time-till-open-source-alternative.html), André Staltz
 - 📰 [Projet GPL Violations](https://gpl-violations.org/) [inactif, archivage]
+- 📰 [Deconstructing Software copyright, 30 years of bad logic](http://www.patenting-art.com/copyprob/softcopy.htm)
 - 📰 [Dossier magazine Swissquote : Les milliards de l'open source](https://resources.swissquote.com/sites/default/files/2020-08/magazine_56_fr.pdf)
 - 📰 [The five stages of the Open Source Program Office](https://blog.opensource.org/the-five-stages-of-the-open-source-program-office/)
 - 📰 [We're living in a post-open source world](https://www.infoworld.com/article/2608576/open-source-software-we-re-living-in-a-post-open-source-world.html)


### PR DESCRIPTION
« For over thirty years, software copyright has been a succession of court cases and law review articles based on bad law, bad logic, bad mathematics, and/or bad physics (Benson, CONTU, Whelan and Altai being all of these). I have decided to write a critical review arguing that software copyright (and dependents like TRIPS, GPL, Bernstein, Junger) should be abolished in light of 17 USC 102b and its equivalents - for one reason - it is bad law with no logical basis in the mathematics and physics of information processing.

What follows is a list of over 90 Acts, decisions and law review articles I will be critiquing in the review. A small number of cases are from Asia and Europe, which inherited the problems of the US cases. »