### PR TITLE
ressources : ajout OERizona Network

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -263,6 +263,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🕴️ 🇫🇷 [Délégation Académique au Numérique Éducatif (DANE)](https://www.ac-paris.fr/delegation-academique-au-numerique-educatif-dane-122341), AC Paris
 - 🕴️ 🇫🇷 [L'éducation ouverte à Nantes Université](https://www.univ-nantes.fr/decouvrir-luniversite/vision-strategie-et-grands-projets/open-education-leducation-ouverte-a-nantes-universite)
 - 🕴️ 🇺🇸 [Community College Consortium for OER](https://www.cccoer.org/) (CCCOER)
+- 🕴️ 🇺🇸 [OERizona Network](https://sites.google.com/scottsdalecc.edu/oerizonanetwork/home)
 - 🕴️ 🇪🇺 [European Network for Catalysing Open Resources in Education](https://encoreproject.eu/) (ENCORE+)
 - 🕴️ [The International Council for Open and Distance Education](https://www.icde.org/) (ICDE)
 - 🕴️ [Open Education Global](https://www.oeglobal.org/)


### PR DESCRIPTION
The OERizona Network is a professional learning community committed to providing learners across Arizona and beyond unimpeded and equitable access to high-quality learning materials through the promotion of open educational practices. The network seeks to cultivate a vibrant community of practitioners and advocates in open education by supporting coordination and collaboration on open educational resource projects and applications of open pedagogies.