### PR TITLE
ressources : ajout open education network + open textbook library

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -255,6 +255,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 📚 [Databases of Open Educational Ressources](https://guides.library.unr.edu/oer/find), by University of Nevada
 - 📚 [Openstax](https://openstax.org/), manuels scolaire en libre accès
 - 📚 [LibreTexts](https://commons.libretexts.org/), réseau de librairies pour manuels
+- 📚 [Open Textbook Library](https://open.umn.edu/opentextbooks), powered by Open Education Network
 - 📚 [Sites de l'innovation pédagogique dans l'enseignement supérieur francophone](https://www.innovation-pedagogique.fr/article39.html)
 - 📚 [Open Source Society University](https://github.com/ossu)
 - 🕴️ 🇫🇷 [Délégation Académique au Numérique Éducatif (DANE)](https://www.ac-paris.fr/delegation-academique-au-numerique-educatif-dane-122341), AC Paris
@@ -262,6 +263,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🕴️ 🇺🇸 [Community College Consortium for OER](https://www.cccoer.org/) (CCCOER)
 - 🕴️ [The International Council for Open and Distance Education](https://www.icde.org/) (ICDE)
 - 🕴️ [Open Education Global](https://www.oeglobal.org/)
+- 🕴️ [Open Education Network](https://open.umn.edu/oen)
 - 🕴️ [Open EdTech](https://www.openedtech.global/), designing a global NextGen educational open source platform
 - 🕴️ 🇺🇸 [MIT Open Learning](https://openlearning.mit.edu/)
 - 🕴️ 🇫🇷 [Fabrique des Communs Pédagogiques](https://fabpeda.org/)


### PR DESCRIPTION
Dave Ernst started the Open Textbook Library (OTL) in 2012 at the University of Minnesota to make finding open textbooks easier for faculty, and launched an accompanying workshop encouraging them to consider open textbooks for their courses. His interest and work in expanding the use of open textbooks was a direct response to escalating textbook costs in higher education and their negative impact on students’ academic success, especially on those who are most financially vulnerable.

In 2014, as more institutions became interested in the OTL and workshop, Dave announced the creation of the Open Textbook Network to provide a space for the institutions to talk with each other about open education. In 2020, the Open Textbook Network became the Open Education Network (OEN), a new name that better reflects the broad scope of the community. Today, the OEN is an open education community of both vision and practice, and the leadership, actions, and results of the community are transforming higher education.