### PR TITLE
feuille de route : utilisation former plutôt que éduquer

### DIFF
--- a/organisation/feuille-de-route.md
+++ b/organisation/feuille-de-route.md
@@ -14,7 +14,7 @@ de ses contraintes financières/de temps/géographiques/etc. Plus d'explications
     <img src="https://raw.githubusercontent.com/Open-Models/Brique/main/images/roadmap.jpg">
 </p>
 
-## Éduquer aux modèles ouverts
+## Former aux modèles ouverts
 
 La mission première de la brique est d'être un outil d'éducation aux modèles ouverts pour favoriser
 la démocratisation de ces concepts émergents. Le numérique concerne toute la société, les modèles ouverts concernent tout


### PR DESCRIPTION
Faire de "l'éducation aux modèles ouverts" me semble plus important que faire de la "formation aux modèles ouverts", dans l'éducation il y a plus cette notion d'une élévation avec un regard critique, pour pousser à penser quand la formation se limite plus à la transmission de connaissances/compétences.

Mais éduquer aux modèles ouverts sonne un peu étrange, l'utilisation du terme former semble plus approprié ici.