### PR TITLE
footer : lien unique sur Github, retrait lien accueil github

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,8 +32,7 @@
 
       <footer class="site-footer">
         {% if site.github.is_project_page %}
-          <span class="site-footer-owner">La <a href="{{ site.github.repository_url }}">{{ site.github.repository_name
-                  }}</a> est maintenue par la communauté sur <a href="https://github.com">GitHub</a>.</span>
+          <span class="site-footer-owner">La {{ site.github.repository_name }} est maintenue par la communauté sur <a href="{{ site.github.repository_url }}">GitHub</a>.</span>
                   <span class="site-footer-credits">
                       Contenu sous licence Creative Commons BY-SA.
                       </br>


### PR DESCRIPTION
Retrait du lien qui pointe sur la page d'acceuil de Github au profit de celui seulement sur le dépôt Github de la brique.

Permet d'éviter la confusion d'arriver sur Github sans comprendre l'envrionnement, les personnes peuvent ensuite explorer le site depuis la page de la brique.