### PR TITLE
ressources : article sur usage termes open hardware/open design

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -346,6 +346,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🕴️ [PinePhone](https://www.pine64.org/)
 - 🕴️ [Open Compute Project](https://www.opencompute.org/)
 - 📰 [Liste de projets open hardware](https://en.wikipedia.org/wiki/List_of_open-source_hardware_projects)
+- 📰 ["Open Design" or "Open Source Hardware"? Lets talk about what?](https://larszimmermann.de/open-design-or-open-source-hardware-lets-talk-about-what/)
 - 📚 [Thingiverse](https://www.thingiverse.com/)
 - 👩🏽‍🔬 [Business models for open source hardware](https://tel.archives-ouvertes.fr/tel-02504769/document)
 


### PR DESCRIPTION
Article qui compare l'intérêt dans l'usage des notions d'open design et d'open hardware, autour de la confusion sur la notion d'hardware qui ne se limite pas au matériel informatique.

Réflexion de l'auteur sur la vocabulaire à adopter pour parler des ces dynamiques, avec l'idée qu'open hardware serait plus consistant.