### PR TITLE
ressources : ajout prereview.org

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -195,6 +195,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🛠️ 🇪🇺 [Open Mining INfrastructure for TExt and Data](http://openminted.eu/) (OpenMinTeD)
 - 🛠️ [Open Researcher and Contributor ID](https://orcid.org/) (ORCID)
 - 🛠️ [Invenio](https://inveniosoftware.org/), open software pour plateforme open science (base de Zenodo)
+- 🛠️ [Prereview](https://prereview.org/), plateforme d'open peer review
 - 📚 [Open Science Framework](https://osf.io/)
 - 📚 [HAL archive ouverte](https://hal.archives-ouvertes.fr/)
 - 📚 [Theses.fr](https://www.theses.fr/fr/)


### PR DESCRIPTION
« PREreview's mission is to bring more equity and transparency to scholarly peer review by supporting and empowering communities of researchers, particularly those at early stages of their career (ECRs) and historically excluded, to review preprints in a process that is rewarding to them. »