### PR TITLE
css : add customisable css file, remove blockquote (right) margin

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,8 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+blockquote {
+    margin-right: 0px;
+}


### PR DESCRIPTION
Add a file to custom the css of the site globally located with Jekyll.

As first needed customisation, remove margin from blockquote, leading to an important space on mobiles.

⚠️ : Not able to find where this margin is coming from at first in css style for the Markdown rendering.

See : https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll#customizing-your-themes-css