### PR TITLE
ressources : ajout Open Research Europe

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -202,6 +202,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🛠️ [Prereview](https://prereview.org/), plateforme d'open peer review
 - 📚 [Open Science Framework](https://osf.io/)
 - 📚 [HAL archive ouverte](https://hal.archives-ouvertes.fr/)
+- 📚 [Open Research Europe](https://open-research-europe.ec.europa.eu/), plateforme publication hébergé par la Commission Européenne
 - 📚 [Theses.fr](https://www.theses.fr/fr/)
 - 📚 [Open Edition](https://www.openedition.org/)
 - 📚 [Open Access Publishing in European Networks](https://www.oapen.org/) (OAPEN)


### PR DESCRIPTION
Plateforme de publication en open access porté par la commission Européenne et Horizon 2020, Horizon Europe...

« The platform makes it easy for Horizon 2020, Horizon Europe and Euratom beneficiaries to comply with the open access terms of their funding and offers researchers a publishing venue to share their results and insights rapidly and facilitate open, constructive research discussion. »