### PR TITLE
ressources : ajout OSPO alliance

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -123,6 +123,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🏦 🇪🇺 [European Free and Open Source Software Auditing](https://commission.europa.eu/about-european-commission/departments-and-executive-agencies/informatics/eu-fossa-2-free-and-open-source-software-auditing_en) (EU-FOSSA-2)
 - 🏦 🇫🇷 Plan d'action logiciels libres et communs numériques : [communs.numerique.gouv.fr](https://communs.numerique.gouv.fr/)
 - 🕴️ [TODO](https://todogroup.org/), for organizations committed to Open Source and Open Source Program Offices
+- 🕴️ [OSPO Alliance](https://ospo.zone/)
 - 🕴️ 🇫🇷 [Addulact](https://adullact.org/)
 - 🕴️ 🇫🇷 [The Open Source I Trust (TOSIT)](https://tosit.fr/)
 - 🕴️ 🇫🇷 [Conseil National du Logiciel Libre](https://cnll.fr/)


### PR DESCRIPTION
The OSPO Alliance was launched in June 2021 by European non profit organisations — OW2, Eclipse Foundation, OpenForum Europe, and Foundation for Public Code — and concerned individuals to promote an approach to excellence in open source software management. Together we created the OSPO Alliance — an open experience-sharing platform to facilitate discovery of tools and best practices and help define the state of the art in this domain.