### PR TITLE
ressources : ajout usage rights licence

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -235,8 +235,10 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 📰 [Liste Wikipédia de dépôts de pré-publication](https://en.wikipedia.org/wiki/List_of_preprint_repositories)
 - 📰 [« La science ouverte est une nouvelle façon de diffuser les savoirs, et les bibliothèques sont au cœur de cette évolution »](https://bbf.enssib.fr/bbffocus/la-science-ouverte-est-une-nouvelle-facon-de-diffuser-les-savoirs-et-les-bibliotheques-sont-au-coeur-de-cette-evolution_70750), interview responsables BU
 - 📰 [The rise and fall of peer review](https://experimentalhistory.substack.com/p/the-rise-and-fall-of-peer-review)
+- 📰 [Se réapproprier la production de connaissance](https://aoc.media/opinion/2023/05/17/se-reapproprier-la-production-de-connaissance/), introduction licence UsageRight
 - 🕴️ [Peer Community In](https://peercommunityin.org/), organization of researchers offering peer review
 - 🛠️ [OpenReview](https://openreview.net/)
+- 🛠️ [Licence UsageRight](https://pbil.univ-lyon1.fr/members/tannier/usageright/accueil_fr.html)
 - 🕴️ [Coalition for Advancing Research Assessment](https://coara.eu/) (CoARA)
 - 🕴️🇫🇷 [Centre pour la Communication Scientifique Directe](https://www.ccsd.cnrs.fr/)
 - 🕴️[OpenAIRE](https://www.openaire.eu/), create and operate services for Open Science


### PR DESCRIPTION
Ajout d'un article et d'un lien sur la licence usageRight, qui pousse à ajouter des conditions d'usage sur le contenu produit, notamment autour des questions écologiques.

Licence pour documents (scientifiques), données et logiciels.

« UsageRight est un principe, fondé sur la propriété intellectuelle, qui permet au personnel de la Recherche de restreindre le droit d'usage sur sa production (articles, logiciels, données), en ne permettant pas l'exploitation de leur œuvre à des fins qu'il considère contraire à sa conception du bien commun. »