### PR TITLE
ressources : ajout article/mémoire Carto-vandalisme dans OpenStreetMap

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -344,6 +344,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 📰 [The world needs a better map: TomTom is making it with its new mapping platform and ecosystem](https://www.tomtom.com/newsroom/behind-the-map/the-future-of-mapmaking-tomtom-maps-platform/) (2022)
 - 🕴️ [Overture Maps Foundation](https://overturemaps.org/), coalition pour des cartes interopérables
 - 👩🏽‍🔬 [Reports for Open Data Maturity of European countries](https://data.europa.eu/en/publications/open-data-maturity/), European Commission
+- 📰 👩🏽‍🔬 [Carto-vandalisme dans OpenStreetMap : mythe ou réalité ?](https://static.geotribu.fr/articles/2023/2023-05-24_carto-vandalisme_dans_OSM/#introduction) (Mémoire)
 
 ## Open Hardware
 


### PR DESCRIPTION
"L'enrichissement des bases de données ouvertes a fait de certains projets collaboratifs de vraies références pour les consommateurs de données, tels que l'encyclopédie libre Wikipédia ou encore le projet OpenStreetMap (OSM), dans un domaine cartographique. OSM est même devenu une base de référence pour les forces de l'ordre.

La qualité de ces nouveaux référentiels repose sur une forte participation de la communauté de contributeurs. Mais comment s'assurer que, dans ce nouvel espace commun, il n'y ait pas de dégradation sur les données introduites ?

C'est sur le sujet du carto-vandalisme dans OSM que j'ai axé mes recherches durant quelques années de thèse à l'IGN (coucou à mes anciens collègues du LASTIG !). Et pour éviter que mon mémoire ne prenne la poussière, je profite qu'on me laisse la parole au micro de GeoTribu pour partager un des fruits de mes recherches 😄."