### PR TITLE
Création page « Matériel d'Atelier d'Éducation aux Modèles Ouverts »

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Une ressource pour se construire des bases et devenir acteur de ces univers.
 
 Une [liste de ressources](ressources.md) sur les modèles ouverts permet de rassembler une variété de liens utiles.
 
+## Matériel d'atelier 📚
+
+L'éducation aux modèles ouverts prend des formes et touche des publics variés, une multitude de matériaux
+pédagogiques peuvent être crées et réutilisés. Pour aider à la mise en place d'activités, tout un ensemble
+de ressources librement disponibles se trouve sur une page dédiée au [matériel pour des ateliers
+d'éducation aux modèles ouverts](materiel-atelier.md).
+
 ## Feuille de route 🗺️
 
 Pour fixer et comprendre l'orientation de la communauté autour de la brique, une [feuille de route](organisation/feuille-de-route.md) permet de voir

--- a/materiel-atelier.md
+++ b/materiel-atelier.md
@@ -1,0 +1,9 @@
+## Matériel d'Atelier d'Éducation aux Modèles Ouverts
+
+Retrouvez ici un ensemble de ressources éducatives ouvertes pour la mise en place d'ateliers pédagogiques
+sur les modèles ouverts. Des ressources qui peuvent être réutilisées telles quelles ou servir de base,
+de source d'inspiration dans la construction de vos propres projets.
+
+### Liste de matériaux pédagogiques sur les modèles ouverts
+
+- [Environnement Pédagogique sur les Modèles Ouverts](https://doi.org/10.5281/zenodo.8002670)


### PR DESCRIPTION
Ajout d'une page pour les OER annexes à la brique utiles pour faire de l'éducation aux modèles ouverts. Fait suite à la création de tout un environnement pédagogique sur les modèles ouverts pour un évènement.

A le potentiel de permettre un meilleur partage, une meilleure réutilisation voir collaboration entre les acteurs de l'éducation aux modèles ouverts.

Peut mettre plus facilement en capacité les acteurs pour mener des ateliers.