### PR TITLE
Ressources : ajout International Association for the Study of the Commons

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -74,6 +74,7 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 🕴️ 🇬🇧 [OpenUk](https://openuk.uk/)
 - 🕴️ [Open Climate](https://open-climate.org/), exploring the intersection between the open movement and the climate crisis
 - 🕴️ [Digital Public Goods Alliance](https://digitalpublicgoods.net/)
+- 🕴️ [International Association for the Study of the Commons](https://iasc-commons.org/) (IASC)
 
 ## Open Source
 


### PR DESCRIPTION
The IASC is the leading professional association dedicated to the commons. The association, founded in 1989, is devoted to bringing together multi-disciplinary researchers, practitioners, and policymakers for the purpose of improving governance and management, advancing understanding, and creating sustainable solutions for commons, common-pool resources, or any other form of shared resource.