### PR TITLE
ressources : ajout multiples bibliothèques de logos

### DIFF
--- a/ressources.md
+++ b/ressources.md
@@ -67,6 +67,10 @@ et notre savoir collectif sera appréciée, idéalement en issue (ou directement
 - 📚 [Unsplash](https://unsplash.com/), banque d'image
 - 📚 [Pixabay](https://pixabay.com/), banque d'images, sons et vidéos libres de droits
 - 📚 [Iconoir](https://iconoir.com/), librairie de logo
+- 📚 [Fontawesome](https://fontawesome.com/), icons library
+- 📚 [The Noun Project](https://thenounproject.com/), icons and photos library
+- 📚 [Fontello](https://fontello.com/), icons library
+- 📚 [Iconmonstr](https://iconmonstr.com), icons library
 - 📚 [Directory of Open Access Books](https://www.doabooks.org/) (DOAB)
 - 🕴️ [Fabrique des mobilités](https://lafabriquedesmobilites.fr/), construire la mobilité durable via les communs
 - 🕴️ [Open Future Foundation](https://openfuture.eu/)


### PR DESCRIPTION
Ajout des bibliothèques d'icônes (+ potentiellement images) Fontawesome, The Noun Project, Iconmonstr and Fontello.

Provient de la liste de sites suivante qui m'a été recommandée : https://www.websiteplanet.com/blog/free-icons-for-commercial-use/

Sélection des sites qui ont tout sous licence ouverte, retrait de ceux qui sont hybrides/open core (creatives commons ou autre licence + contenu premium). Sauf Fontawesome vu que c'est répandu.

Choix délicat entre lister tout ce qui existe avec du contenu ouvert (mais avec du fermé également), ou se limiter à une sélection de sites les plus ouverts (ou connu).