### PR TITLE
resources: add Open Hardware Certification Program

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -403,6 +403,7 @@ In the spirit of contribution, any recommendation that will enrich this list of 
 
 ## Open Hardware
 
+- [The Open Hardware Certification Program](https://web.archive.org/web/19990224114406/http://www.openhardware.org/), by Bruce Perens [archive]
 - 🎥 [Le libre et l'open source des logiciels et objets - monsieur Bidouille](https://www.youtube.com/watch?v=y2GNVGagWdM)
 - 🕴️ [Arduino](https://www.arduino.cc/)
 - 🛠️ [Prusa](https://www.prusa3d.com/), 3D printers


### PR DESCRIPTION
Original open hardware coining by B. Perens, used for open programing API: « By certifying a hardware device as Open, the manufacturer makes a set of promises about the availability of documentation for programming the device-driver interface of a specific hardware device. »